### PR TITLE
cbs_get_meta() gives error

### DIFF
--- a/R/cbs_default_selection.R
+++ b/R/cbs_default_selection.R
@@ -21,7 +21,9 @@ cbs_default_selection <- function(x, ...){
   })
   
   names(codes) <- vars
-  codes$select <- strsplit(params$`$select`, ", ")[[1]]
+  if(!is.null(params$`$select`)){
+    codes$select <- strsplit(params$`$select`, ", ")[[1]]
+  }
   c(id = x$TableInfos$Identifier, codes)
 }
 


### PR DESCRIPTION
For tables that do not have a select-statement in the TableInfos$DefaultSelection cbs_get_meta() prints an error. See for example cbs_get_meta("84134NED").

The problem is only in the text that is printed. The resulting object is retrieved correctly, i.e. the following works fine:
meta_data <- cbs_get_meta("84134NED") 
The error is confusing, because it looks like something went wrong.
Please review suggested solution.