### PR TITLE
Handle tables with multiple time and/or region columns.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,8 @@ License: GPL-2
 URL: https://github.com/edwindj/cbsodataR
 BugReports: https://github.com/edwindj/cbsodataR/issues
 Encoding: UTF-8
+Depends:
+    R (>= 4.1.0)
 Imports:
     whisker,
     jsonlite,

--- a/R/cbs_get_data.R
+++ b/R/cbs_get_data.R
@@ -93,13 +93,13 @@ cbs_get_data <- function( id
   }
   
   is_time <- meta$DataProperties$Key[meta$DataProperties$Type == "TimeDimension"]
-  if (length(is_time)){
-    attr(data[[is_time]], "is_time") <- TRUE
+  for (col in is_time) {
+    attr(data[[col]], "is_time") <- TRUE
   }
   
   is_region <- meta$DataProperties$Key[meta$DataProperties$Type == "GeoDimension"]
-  if (length(is_region)){
-    attr(data[[is_region]], "is_region") <- TRUE
+  for (col in is_region) {
+    attr(data[[col]], "is_region") <- TRUE
   }
   
   class(data) <- c('tbl_df', 'tbl','data.frame')


### PR DESCRIPTION
I ran into an issue with `cbs_get_data` when a table contains multiple region columns. This should fix this. As the same code is used for time columns, I also applied the same fix to time columns (not sure if that can happen). 

This triggers the issue:

```R
tab_inter <- "81734NED"
library(cbsodataR)
inter <- cbs_get_data(tab_inter, Perioden = "2023JJ00", RegioVanVertrek = has_substring("GM0363"))
```

This table has two region columns. 

